### PR TITLE
fix(Compiler): production build was not rendering some components

### DIFF
--- a/addon/ng2/models/webpack-build-production.ts
+++ b/addon/ng2/models/webpack-build-production.ts
@@ -21,7 +21,7 @@ export const getWebpackProdConfigPartial = function(projectRoot: string, sourceD
       // ~107kb
       new webpack.optimize.UglifyJsPlugin({
         beautify: false, //prod
-        mangle: { screw_ie8 : true }, //prod
+        mangle: { screw_ie8 : true, keep_fnames: true }, //prod
         compress: { screw_ie8: true }, //prod
         comments: false //prod
       }),


### PR DESCRIPTION
fix(Compiler): production build was not rendering some components

This fixes the issue #1644

Changed mangle configution passed to UglifyJsPlugin to `mangle: { screw_ie8 : true, keep_fnames: true }`
